### PR TITLE
Reschedule snap refresh

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -23,3 +23,7 @@ end
 execute 'install lxd using snap' do
   command "sudo snap install lxd --channel=#{node[cookbook_name]['lxd_snap_channel']}"
 end
+
+execute "reschedule snap refresh time" do
+  command "sudo snap set system refresh.timer=wed5,23:00-01:00"
+end

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -16,3 +16,8 @@ end
 describe command('sysctl vm.max_map_count') do
   its('stdout') { should eq "vm.max_map_count = 262144\n" }
 end
+
+describe command('snap refresh --time') do
+  its('stdout') { should match /timer: wed5,23:00-01:00/ }
+end
+

--- a/test/integration/registry_node/default.rb
+++ b/test/integration/registry_node/default.rb
@@ -12,3 +12,7 @@ end
 describe command('sysctl vm.max_map_count') do
   its('stdout') { should eq "vm.max_map_count = 262144\n" }
 end
+
+describe command('snap refresh --time') do
+  its('stdout') { should match /timer: wed5,23:00-01:00/ }
+end


### PR DESCRIPTION
Currently, default snap refresh schedule is 00:00~24:00/4 (4 times/day). Reschedule it to atleast once per month and at midnight.